### PR TITLE
Added oid to login response

### DIFF
--- a/app/Controllers/Http/AuthController.ts
+++ b/app/Controllers/Http/AuthController.ts
@@ -5,9 +5,10 @@ import { NationOwnerScopes } from 'App/Utils/Scopes'
 export default class AuthController {
     public async login({ request, auth }: HttpContextContract) {
         const { email, password } = await request.validate(UserValidator)
-
         const token = await auth.use('api').attempt(email, password)
-        let scope: string = NationOwnerScopes.None
+
+        let scope = NationOwnerScopes.None
+        let oid = -1
 
         // Set scope depending on what user is
         // If nationId is not part of a nation (-1),
@@ -18,11 +19,14 @@ export default class AuthController {
             } else {
                 scope = NationOwnerScopes.Staff
             }
+
+            oid = auth.user.nationId
         }
 
         return {
             ...token.toJSON(),
             scope,
+            oid,
         }
     }
 }

--- a/app/Models/User.ts
+++ b/app/Models/User.ts
@@ -13,7 +13,7 @@ export default class User extends BaseModel {
     public password: string
 
     // The nation that this user is a part of
-    @column({ serializeAs: null })
+    @column({ serializeAs: 'oid' })
     public nationId: number
 
     // If the user is a nation admin

--- a/app/Utils/Test.ts
+++ b/app/Utils/Test.ts
@@ -11,11 +11,12 @@ export async function createStaffUser(nationId: number, nationAdmin: boolean) {
         .send({ email: user.email, password })
         .expect(200)
 
-    const { token, scope } = JSON.parse(text)
+    const { token, scope, oid } = JSON.parse(text)
 
     return {
         user,
         token,
         scope,
+        oid,
     }
 }

--- a/database/migrations/1587988332388_users.ts
+++ b/database/migrations/1587988332388_users.ts
@@ -6,7 +6,7 @@ export default class UsersSchema extends BaseSchema {
     public async up() {
         this.schema.createTable(this.tableName, (table) => {
             table.increments('id').primary()
-            table.integer('nation_id')
+            table.integer('nation_id').defaultTo(-1)
             table.boolean('nation_admin').defaultTo(false)
             table.string('email', 255).notNullable()
             table.string('password', 180).notNullable()

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -24,10 +24,12 @@ test.group('Auth', () => {
         const data = JSON.parse(text)
 
         assert.isString(data.token)
-        assert.equal(data.type, 'bearer')
+        assert.equal('bearer', data.type)
+        assert.equal(NationOwnerScopes.None, data.scope)
+        assert.equal(-1, data.oid)
     })
 
-    test('ensure email is validated', async (assert) => {
+    test('ensure email is validated', async () => {
         await supertest(BASE_URL)
             .post('/user/login')
             .expect('Content-Type', /json/)
@@ -38,7 +40,7 @@ test.group('Auth', () => {
             .expect(422)
     })
 
-    test('ensure password is validated', async (assert) => {
+    test('ensure password is validated', async () => {
         await supertest(BASE_URL)
             .post('/user/login')
             .expect('Content-Type', /json/)
@@ -49,7 +51,7 @@ test.group('Auth', () => {
             .expect(422)
     })
 
-    test('ensure both email and password is validated', async (assert) => {
+    test('ensure both email and password is validated', async () => {
         await supertest(BASE_URL)
             .post('/user/login')
             .expect('Content-Type', /json/)
@@ -68,7 +70,7 @@ test.group('Auth', () => {
             password: '12345678',
         })
 
-        assert.equal(user.email, email)
+        assert.equal(email, user.email)
     })
 
     test('ensure user password gets hashed during save', async (assert) => {
@@ -77,25 +79,30 @@ test.group('Auth', () => {
             password: '12345678',
         })
 
-        assert.notEqual(user.password, 'secret')
+        assert.notEqual('secret', user.password)
     })
 
     test('ensure that logging in as admin returns the "admin" scope', async (assert) => {
         const { oid } = await NationFactory.create()
-        const { scope } = await createStaffUser(oid, true)
+        const data = await createStaffUser(oid, true)
 
-        assert.equal(scope, NationOwnerScopes.Admin)
+        assert.equal(NationOwnerScopes.Admin, data.scope)
+        assert.equal(oid, data.oid)
     })
 
     test('ensure that logging in as staff returns the "staff" scope', async (assert) => {
         const { oid } = await NationFactory.create()
-        const { scope } = await createStaffUser(oid, false)
+        const data = await createStaffUser(oid, false)
 
-        assert.equal(scope, NationOwnerScopes.Staff)
+        assert.equal(NationOwnerScopes.Staff, data.scope)
+        assert.equal(oid, data.oid)
     })
 
     test('ensure that logging in as a user with no nation relation returns the "none" scope', async (assert) => {
-        const { scope } = await createStaffUser(-1, false)
-        assert.equal(scope, NationOwnerScopes.None)
+        const oid = -1
+        const data = await createStaffUser(oid, false)
+
+        assert.equal(NationOwnerScopes.None, data.scope)
+        assert.equal(oid, data.oid)
     })
 })


### PR DESCRIPTION
The login response now also returns the nation that the user is a part of:

```json
{
    "type": "bearer",
    "token": "<opaque token>",
    "scope": "<admin|staff|none>",
    "oid": <oid>
}
```

Everything so far has been documented [here](https://github.com/dsp-krabby/docs/pull/7)