### PR TITLE
Fixed invalid absolute URL generation for static assets

### DIFF
--- a/app/Utils/Serialize.ts
+++ b/app/Utils/Serialize.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import { HOSTNAME } from 'App/Utils/Constants'
 
 export function toBoolean(value: number) {
@@ -6,5 +5,5 @@ export function toBoolean(value: number) {
 }
 
 export function toAbsolutePath(value: string) {
-    return value ? path.join(HOSTNAME, value) : value
+    return value ? HOSTNAME + '/' + value : value
 }

--- a/database/factories/index.ts
+++ b/database/factories/index.ts
@@ -88,8 +88,6 @@ export const NationFactory = Factory.define(Nation, async ({ faker }) => {
         shortName: faker.company.companyName(),
         description: faker.lorem.paragraph(),
         accentColor: faker.internet.color(),
-        coverImgSrc: faker.image.imageUrl(),
-        iconImgSrc: faker.image.avatar(),
     }
 })
     .relation('staff', () => UserFactory)


### PR DESCRIPTION
Fixes an issue where the generated absolute URL would contain `http:/` instead of `http://`.