### PR TITLE
Set upload fields of nation to optional

### DIFF
--- a/app/Validators/Nations/UploadValidator.ts
+++ b/app/Validators/Nations/UploadValidator.ts
@@ -6,11 +6,11 @@ export default class NationUploadValidator {
     constructor(protected ctx: HttpContextContract) {}
 
     public schema = schema.create({
-        cover: schema.file({
+        cover: schema.file.optional({
             size: MAX_FILE_SIZE,
             extnames: ALLOWED_FILE_EXTS,
         }),
-        icon: schema.file({
+        icon: schema.file.optional({
             size: MAX_FILE_SIZE,
             // TODO: Allow svg?
             extnames: ALLOWED_FILE_EXTS,

--- a/test/nation.spec.ts
+++ b/test/nation.spec.ts
@@ -225,7 +225,7 @@ test.group('Nation upload', (group) => {
             .post(`/nations/${nation.oid}/upload`)
             .set('Authorization', 'Bearer ' + nation.token)
             .send({ randomData: 'hello' })
-            .expect(422)
+            .expect(400)
     })
 
     test('ensure that uploading images to a non-existant nation fails', async () => {


### PR DESCRIPTION
Previously, you were required to set both images even though you should only need to set one. This fixes this and updates a failing test in result of it (since both are optional the request will be deemed invalid since it will contain no data).