### PR TITLE
Changed format of event times to ISO

### DIFF
--- a/app/Models/Event.ts
+++ b/app/Models/Event.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { toAbsolutePath, toHour } from 'App/Utils/Serialize'
+import { toAbsolutePath, toISO } from 'App/Utils/Serialize'
 import { column, BaseModel } from '@ioc:Adonis/Lucid/Orm'
 
 export default class Event extends BaseModel {
@@ -27,15 +27,15 @@ export default class Event extends BaseModel {
     @column({ serialize: toAbsolutePath })
     public coverImgSrc: string
 
+    @column.dateTime({ serialize: toISO })
+    public occursAt: DateTime
+
+    @column.dateTime({ serialize: toISO })
+    public endsAt: DateTime
+
     @column.dateTime({ autoCreate: true, autoUpdate: true, serializeAs: null })
     public updatedAt: DateTime
 
     @column.dateTime({ autoCreate: true, serializeAs: null })
     public createdAt: DateTime
-
-    @column.dateTime({ serialize: toHour })
-    public occursAt: DateTime
-
-    @column.dateTime({ serialize: toHour })
-    public endsAt: DateTime
 }

--- a/app/Utils/Serialize.ts
+++ b/app/Utils/Serialize.ts
@@ -12,3 +12,7 @@ export function toAbsolutePath(value: string) {
 export function toHour(value: DateTime) {
     return value ? value.toFormat('HH:mm') : value
 }
+
+export function toISO(value?: DateTime) {
+    return value ? value.setZone('utc').toISO() : value
+}

--- a/app/Utils/Upload.ts
+++ b/app/Utils/Upload.ts
@@ -5,7 +5,7 @@ import Application from '@ioc:Adonis/Core/Application'
 import { MultipartFileContract } from '@ioc:Adonis/Core/BodyParser'
 
 export const MAX_FILE_SIZE = '3mb'
-// TODO: add .svg? 
+// TODO: add .svg?
 export const ALLOWED_FILE_EXTS = ['jpg', 'png', 'jpeg', 'gif']
 
 export async function attemptFileUpload(file: MultipartFileContract | null) {

--- a/app/Validators/Events/CreateValidator.ts
+++ b/app/Validators/Events/CreateValidator.ts
@@ -6,6 +6,7 @@ export default class EventCreateValidator {
     constructor(protected ctx: HttpContextContract) {}
 
     public refs = schema.refs({ nationId: this.ctx.request?.nation?.oid })
+
     public schema = schema.create({
         name: schema.string(),
         description: schema.string(),
@@ -17,8 +18,8 @@ export default class EventCreateValidator {
             }),
         ]),
 
-        occurs_at: schema.date({ format: 'HH:mm' }, [rules.beforeField('ends_at')]),
-        ends_at: schema.date({ format: 'HH:mm' }, [rules.afterField('occurs_at')]),
+        occurs_at: schema.date({ format: 'iso' }, [rules.beforeField('ends_at')]),
+        ends_at: schema.date({ format: 'iso' }, [rules.afterField('occurs_at')]),
     })
 
     public messages = {}

--- a/app/Validators/Events/UpdateValidator.ts
+++ b/app/Validators/Events/UpdateValidator.ts
@@ -6,6 +6,7 @@ export default class EventUpdateValidator {
     constructor(protected ctx: HttpContextContract) {}
 
     public refs = schema.refs({ nationId: this.ctx.request?.nation?.oid })
+
     public schema = schema.create({
         name: schema.string.optional(),
         description: schema.string.optional(),
@@ -17,8 +18,8 @@ export default class EventUpdateValidator {
             }),
         ]),
 
-        occurs_at: schema.date.optional({ format: 'HH:mm' }, [rules.beforeField('ends_at')]),
-        ends_at: schema.date.optional({ format: 'HH:mm' }, [rules.afterField('occurs_at')]),
+        occurs_at: schema.date.optional({ format: 'iso' }, [rules.beforeField('ends_at')]),
+        ends_at: schema.date.optional({ format: 'iso' }, [rules.afterField('occurs_at')]),
     })
 
     public messages = {}


### PR DESCRIPTION
Events now actually describe which date the event occurs at, along with the time. Both `occurs_at` and `ends_at` will now be serialized to ISO. 