### PR TITLE
Use ASSET_HOSTNAME to calculcate absolute URLs

### DIFF
--- a/app/Utils/Constants.ts
+++ b/app/Utils/Constants.ts
@@ -1,2 +1,6 @@
-export const HOSTNAME = `http://${process.env.HOST}:${process.env.PORT}`
+/**
+ * Generates the hostname for the API.
+ * Mainly used for calculating the absolute URL for public assets.
+ */
+export const HOSTNAME = process.env.ASSET_HOSTNAME ? process.env.ASSET_HOSTNAME : `http://${process.env.HOST}:${process.env.PORT}`
 export const BASE_URL = `${HOSTNAME}/api/v1`


### PR DESCRIPTION
Fixes the issue with images not loading correctly because of invalid domain prefix in asset URL. 