### PR TITLE
Fixed typescript compilation error in event pagination

### DIFF
--- a/app/Controllers/Http/EventsController.ts
+++ b/app/Controllers/Http/EventsController.ts
@@ -52,6 +52,21 @@ export default class EventsController {
     }
 
     /**
+     * Helper function for getting the page number from a request.
+     * If no page number was specified, {@link MINIMUM_PAGE} is returned.
+     * This was added because during typescript compilation in production build,
+     * it would fail and the server could not start. This was a result of the `??`
+     * operator.
+     */
+    private getPageNumber(page?: number) {
+        if (page) {
+            return page
+        }
+
+        return MINIMUM_PAGE
+    }
+
+    /**
      * Method to retrieve all the events in the system
      * The actual function call is done by a request (CRUD) which are specified
      * in `Routes.ts`
@@ -64,7 +79,7 @@ export default class EventsController {
             this.applyFilters(scopes, filters)
         })
 
-        const events = await query.paginate(specified.page ?? MINIMUM_PAGE, specified.amount)
+        const events = await query.paginate(this.getPageNumber(specified.page), specified.amount)
         return events.toJSON()
     }
 
@@ -86,7 +101,7 @@ export default class EventsController {
                 this.applyFilters(scopes, filters)
             })
 
-        const events = await query.paginate(specified.page ?? MINIMUM_PAGE, specified.amount)
+        const events = await query.paginate(this.getPageNumber(specified.page), specified.amount)
         return events.toJSON()
     }
 


### PR DESCRIPTION
Fixes an error in typescript compilation in production when using the `??` operator.