### PR TITLE
added support to filter out events based on excluding OIDs

### DIFF
--- a/app/Models/Event.ts
+++ b/app/Models/Event.ts
@@ -155,4 +155,14 @@ export default class Event extends BaseModel {
     public static perCategory = scope((query, categoryId: number) => {
         query.where('categoryId', categoryId)
     })
+
+    /**
+     * filtering options to query events for their oid belonging
+     * @param categoryId the number for the id to query for
+     */
+    public static filterOutOids = scope((query, oids?: Array<number>) => {
+        if (oids) {
+            query.whereNotIn('nationId', oids)
+        }
+    })
 }

--- a/app/Validators/Events/FilterValidator.ts
+++ b/app/Validators/Events/FilterValidator.ts
@@ -13,6 +13,7 @@ export default class EventFilterValidator {
         before: schema.date.optional({ format: 'yyyy-LL-dd' }),
         after: schema.date.optional({ format: 'yyyy-LL-dd' }),
         category: schema.number.optional([rules.unsigned()]),
+        exclude_oids: schema.string.optional(),
     })
 
     public messages = {}


### PR DESCRIPTION
It is now possible to exlude nation specific events in the system. It is done by proposing a given filter out parameter. This parameter can be  a single oid or multiple. 

Example:
```json
GET /api/v1/events?exclude_oids= <number>, <number2>, ... , <numberN>
```

It also handles if a given parameter is not a number, or if it is an empty parameter. 

Closes #112 
Co-authored-by: Fredrik Engstrand fredrik@engstrand.nu