### PR TITLE
Typo categories

### DIFF
--- a/app/Utils/Categories.ts
+++ b/app/Utils/Categories.ts
@@ -7,16 +7,16 @@
  * @enum Categories The enum type for the different categories available
  */
 export enum Categories {
-    Breakfast = 'Frukost',
+    Breakfast = 'Breakfast',
     Brunch = 'Brunch',
     Lunch = 'Lunch',
     Fika = 'Fika',
     Sport = 'Sport',
-    Restaurant = 'Restaurang',
+    Restaurant = 'Restaurant',
     Pub = 'Pub',
-    Culture = 'Kultur',
+    Culture = 'Culture',
     Gasque = 'Gasque',
     Club = 'Club',
-    Consert = 'Konsert',
-    Other = 'Övrigt',
+    Consert = 'Consert',
+    Other = 'Other',
 }


### PR DESCRIPTION
Changed the language in categories to english in the enum type. Made no sense really having them in swedish since everywhere it is set to be english. Also fixed a typo in one of the types because it is so goddamn hard sometimes to differ how to write the word `Restaurant`.