### PR TITLE
refactored field in menu model so that it stays consistent with other models of the system.

### DIFF
--- a/app/Models/Menu.ts
+++ b/app/Models/Menu.ts
@@ -24,7 +24,7 @@ export default class Menu extends BaseModel {
     //       Or rather, is there an easier way to verify that a certain user is
     //       allowed to access the resource? Right now, we must extract the oid
     //       somehow from every resource that we need to modify.
-    @column({ serializeAs: 'oid' })
+    @column()
     public nationId: number
 
     /**

--- a/test/menu.spec.ts
+++ b/test/menu.spec.ts
@@ -158,7 +158,7 @@ test.group('Menu create', async (group) => {
 
         assert.deepEqual(data.name, menuData.name)
         assert.deepEqual(data.hidden, menuData.hidden)
-        assert.deepEqual(data.oid, nation.oid)
+        assert.deepEqual(data.nation_id, nation.oid)
         assert.deepEqual(data.location_id, location.id)
     })
 


### PR DESCRIPTION
The field that specified which nation the menu belonged to is now changed from `oid` to `nation_id` in the response. There was a serialization placed in the field that changed it before.

Closes #140